### PR TITLE
Update rampart

### DIFF
--- a/environment-beta.yml
+++ b/environment-beta.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3
+  - python>=3.6
   - nodejs=12
   - biopython=1.74
   - bwa=0.7.17=pl5.22.0_2

--- a/environment-beta.yml
+++ b/environment-beta.yml
@@ -28,7 +28,7 @@ dependencies:
   - minimap2=2.17
   - seqtk=1.3
   - bcftools=1.9
-  - artic-network::rampart=1.0
+  - artic-network::rampart=1.1
   - pip
   - pip:
     - git+https://github.com/artic-network/fieldbioinformatics.git

--- a/environment-medaka-beta.yml
+++ b/environment-medaka-beta.yml
@@ -27,7 +27,7 @@ dependencies:
   - datrie=0.8
   - longshot
   - snakemake-minimal=5.8.1
-  - artic-network::rampart=1.0
+  - artic-network::rampart=1.1
   - pip
   - pip:
     - git+https://github.com/artic-network/fieldbioinformatics.git

--- a/environment-medaka-beta.yml
+++ b/environment-medaka-beta.yml
@@ -12,7 +12,6 @@ dependencies:
   - python=3.6.7
   - pyvcf=0.6.8
   - samtools=1.9
-  - python=3
   - nodejs=12
   - bwa=0.7.17=pl5.22.0_2
   - clint=0.5.1=py36_0

--- a/environment-medaka.yml
+++ b/environment-medaka.yml
@@ -27,7 +27,7 @@ dependencies:
   - datrie=0.8
   - longshot=0.4.1
   - snakemake-minimal=5.8.1
-  - artic-network::rampart=1.0
+  - artic-network::rampart=1.1
   - pip
   - pip:
     - git+https://github.com/artic-network/fieldbioinformatics.git

--- a/environment-medaka.yml
+++ b/environment-medaka.yml
@@ -12,7 +12,6 @@ dependencies:
   - python=3.6.7
   - pyvcf=0.6.8
   - samtools=1.9
-  - python=3
   - nodejs=12
   - bwa=0.7.17=pl5.22.0_2
   - clint=0.5.1=py36_0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3
+  - python>=3.6
   - nodejs=12
   - biopython=1.74
   - bwa=0.7.17=pl5.22.0_2

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - minimap2=2.17
   - seqtk=1.3
   - bcftools=1.9
-  - artic-network::rampart=1.0
+  - artic-network::rampart=1.1
   - pip
   - pip:
     - git+https://github.com/artic-network/fieldbioinformatics.git


### PR DESCRIPTION
* Enforce python>=3.6 in conda environments 
* Upgrade RAMPART to 1.1

Tested by creating a new environment & running rampart on SARS-CoV-2 fastqs. 